### PR TITLE
Fix frame update events and portrait click disable

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -17,7 +17,7 @@ RUF.utils = RUF.utils or {}
 local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 eventFrame:RegisterEvent("UNIT_HEALTH")
-eventFrame:RegisterEvent("UNIT_POWER_UPDATE")
+eventFrame:RegisterEvent("UNIT_MAXHEALTH")
 eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 
 -- Reusable health bar update logic

--- a/Menu.lua
+++ b/Menu.lua
@@ -259,9 +259,13 @@ function RUF:CreateOptionsMenu()
 				frame.healthText:Hide()
 
 				-- disable clicks
-				frame:EnableMouse(false)
-				portrait2DFrame:EnableMouse(false)
-				portraitContainer:EnableMouse(false)
+                                frame:EnableMouse(false)
+                                if frame.portrait2DFrame then
+                                        frame.portrait2DFrame:EnableMouse(false)
+                                end
+                                if frame.portraitContainer then
+                                        frame.portraitContainer:EnableMouse(false)
+                                end
 			else
 				frame.healthBar:Show()
 				frame.healthBarBG:Show()


### PR DESCRIPTION
## Summary
- register `UNIT_MAXHEALTH` events in `Core.lua`
- avoid nil error when toggling portrait clicks in menu

## Testing
- `apt-get update` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68892ce17c808330bdd2b29a4932f904